### PR TITLE
fix: OAuth token refresh, infinite recursion, and pre-signed URL auth in OneDrive client

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,11 @@
 name: Keboola Component Build & Deploy Pipeline
 on:
   push:
-    branches:
-      - 'feature/*'
-      - 'bug/*'
+    branches-ignore:
+      - main
     tags:
-      - '*' # Skip the workflow on the main branch without tags
+      - "*"  # Skip the workflow on the main branch without tags
+  workflow_dispatch:
 
 concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
 env:
@@ -47,7 +47,7 @@ jobs:
             echo "branch_name=$branch_name" | tee -a $GITHUB_OUTPUT
           else
             raw=$(git branch -r --contains ${{ github.ref }})
-            branch="$(echo $raw | sed "s/.*origin\///" | tr -d '\n')"
+            branch="$(echo ${raw/*origin\//} | tr -d '\n')"
             echo "branch_name=$branch" | tee -a $GITHUB_OUTPUT
           fi
 
@@ -64,8 +64,13 @@ jobs:
       - name: Set image tag
         id: tag
         run: |
-          TAG="${GITHUB_REF##*/}"
-          IS_SEMANTIC_TAG=$(echo "$TAG" | grep -q '^v\?[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
+          REF="${GITHUB_REF##*/}"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG="$REF"
+          else
+            TAG="$REF-${{ github.run_number }}"
+          fi
+          IS_SEMANTIC_TAG=$(echo "$REF" | grep -q '^[0-9]\+\.[0-9]\+\.[0-9]\+$' && echo true || echo false)
           echo "is_semantic_tag=$IS_SEMANTIC_TAG" | tee -a $GITHUB_OUTPUT
           echo "app_image_tag=$TAG" | tee -a $GITHUB_OUTPUT
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -102,7 +102,7 @@ class OneDriveClient(HttpClient):
         """
         This is handled using requests to handle compatibility with OneDrive and Sharepoint client.
         """
-        logging.info(f"Fetching New Access token from {self.auth_url}")
+        logging.debug(f"Fetching new access token from {self.auth_url}")
         request_url = f"{self.auth_url}/oauth2/v2.0/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         payload = {
@@ -126,7 +126,7 @@ class OneDriveClient(HttpClient):
                 f"Reauthorize the extractor in extractor configuration."
             )
 
-        logging.info("New Access token fetched.")
+        logging.debug("New access token fetched.")
         self.access_token = token
         self._refresh_token = response.json()["refresh_token"]
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -16,6 +16,11 @@ class OneDriveClientException(Exception):
     pass
 
 
+class OneDriveTransientException(OneDriveClientException):
+    """Raised for transient HTTP errors (429, 5xx) that are safe to retry."""
+    pass
+
+
 class OneDriveClient(HttpClient):
     """
     The OneDriveClient class manages the interaction with OneDrive API. It handles tasks such as
@@ -138,19 +143,34 @@ class OneDriveClient(HttpClient):
         return self._refresh_token
 
     def get_request(self, url: str, is_absolute_path: bool, stream: bool = False):
-        response = self.get_raw(url, is_absolute_path=is_absolute_path, stream=stream)
-        if response.status_code == 200:
-            return response
-        elif response.status_code == 401:
-            self._get_request_tokens()
-            return self.get_request(url, is_absolute_path, stream)
-        elif response.status_code == 404:
-            logging.error(f"Url {url} returned 404.")
-            return None
-        else:
-            raise OneDriveClientException(f"Cannot fetch {url}, "
-                                          f"response: {response.text}, "
-                                          f"status_code: {response.status_code}")
+        for attempt in range(2):
+            response = self.get_raw(url, is_absolute_path=is_absolute_path, stream=stream)
+            if response.status_code == 200:
+                return response
+            elif response.status_code == 404:
+                logging.error(f"Url {url} returned 404.")
+                return None
+            elif response.status_code == 401:
+                if attempt == 0:
+                    logging.warning(f"Got 401 fetching {url}, refreshing token and retrying...")
+                    self._get_request_tokens()
+                    continue
+                error_body = response.json()
+                error_code = error_body.get("error", "unknown")
+                error_desc = error_body.get("error_description", "no description")
+                raise OneDriveClientException(
+                    f"Authentication failed after token refresh (HTTP 401): "
+                    f"{error_code} - {error_desc}"
+                )
+            elif response.status_code in (429, 500, 502, 503, 504):
+                raise OneDriveTransientException(
+                    f"Transient error fetching {url}: HTTP {response.status_code} - {response.text}"
+                )
+            else:
+                raise OneDriveClientException(
+                    f"Cannot fetch {url}, response: {response.text}, "
+                    f"status_code: {response.status_code}"
+                )
 
     def _resolve_folder_id(self, drive_type: str, folder_path: str):
         if folder_path is None or folder_path == '/':
@@ -302,7 +322,7 @@ class OneDriveClient(HttpClient):
             raise OneDriveClientException(f"Error occurred when getting SharePoint document libraries:"
                                           f" {response.status_code}, {response.text}")
 
-    @backoff.on_exception(backoff.expo, Exception, max_tries=MAX_RETRIES)
+    @backoff.on_exception(backoff.expo, OneDriveTransientException, max_tries=MAX_RETRIES)
     def _download_file_from_onedrive_url(self, url, output_path, filename):
         """
         Downloads a file from OneDrive using the provided download URL and saves it to the specified output path.

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -74,7 +74,7 @@ class OneDriveClient(HttpClient):
     def _configure_onedrive_client(self):
         logging.info("Initializing OneDrive client")
         self.client_type = "OneDrive"
-        self.authority = 'https://login.microsoftonline.com/common'
+        self.auth_url = 'https://login.microsoftonline.com/common'
         self.base_url = 'https://graph.microsoft.com/v1.0/me'
         self.scope = 'User.Read Files.Read.All offline_access'
         self._get_request_tokens()
@@ -82,7 +82,7 @@ class OneDriveClient(HttpClient):
     def _configure_sharepoint_client(self):
         logging.info("Initializing Sharepoint client")
         self.client_type = "Sharepoint"
-        self.authority = f'https://login.microsoftonline.com/{self.tenant_id}'
+        self.auth_url = f'https://login.microsoftonline.com/{self.tenant_id}'
         self.scope = 'Sites.Read.All Files.Read.All offline_access'
         self.base_url = 'https://graph.microsoft.com/v1.0/sites/'
         # We need access token to get site id and url
@@ -93,7 +93,7 @@ class OneDriveClient(HttpClient):
     def _configure_onedrive_for_business_client(self):
         logging.info("Initializing OneDriveForBusiness client")
         self.client_type = "OneDriveForBusiness"
-        self.authority = f'https://login.microsoftonline.com/{self.tenant_id}'
+        self.auth_url = f'https://login.microsoftonline.com/{self.tenant_id}'
         self.base_url = 'https://graph.microsoft.com/v1.0/me/drive'
         self.scope = 'Sites.Read.All Files.Read.All offline_access'
         self._get_request_tokens()
@@ -102,8 +102,8 @@ class OneDriveClient(HttpClient):
         """
         This is handled using requests to handle compatibility with OneDrive and Sharepoint client.
         """
-        logging.info(f"Fetching New Access token from {self.authority}")
-        request_url = f"{self.authority}/oauth2/v2.0/token"
+        logging.info(f"Fetching New Access token from {self.auth_url}")
+        request_url = f"{self.auth_url}/oauth2/v2.0/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         payload = {
             "client_id": self.client_id,

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -327,7 +327,7 @@ class OneDriveClient(HttpClient):
         """
         Downloads a file from OneDrive using the provided download URL and saves it to the specified output path.
         """
-        with self.get_request(url, is_absolute_path=True, stream=True) as r:
+        with self.get_raw(url, is_absolute_path=True, stream=True, ignore_auth=True) as r:
 
             if r is None:
                 self._handle_no_response(filename)

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -102,8 +102,8 @@ class OneDriveClient(HttpClient):
         """
         This is handled using requests to handle compatibility with OneDrive and Sharepoint client.
         """
-        logging.info("Fetching New Access token")
-        request_url = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+        logging.info(f"Fetching New Access token from {self.authority}")
+        request_url = f"{self.authority}/oauth2/v2.0/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         payload = {
             "client_id": self.client_id,

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -143,16 +143,17 @@ class OneDriveClient(HttpClient):
         return self._refresh_token
 
     def get_request(self, url: str, is_absolute_path: bool, stream: bool = False):
+        url_path = urlparse(url).path
         for attempt in range(2):
             response = self.get_raw(url, is_absolute_path=is_absolute_path, stream=stream)
             if response.status_code == 200:
                 return response
             elif response.status_code == 404:
-                logging.error(f"Url {url} returned 404.")
+                logging.error(f"URL {url_path} returned 404.")
                 return None
             elif response.status_code == 401:
                 if attempt == 0:
-                    logging.warning(f"Got 401 fetching {url}, refreshing token and retrying...")
+                    logging.warning(f"Got 401 fetching {url_path}, refreshing token and retrying...")
                     self._get_request_tokens()
                     continue
                 error_body = response.json()
@@ -164,11 +165,11 @@ class OneDriveClient(HttpClient):
                 )
             elif response.status_code in (429, 500, 502, 503, 504):
                 raise OneDriveTransientException(
-                    f"Transient error fetching {url}: HTTP {response.status_code} - {response.text}"
+                    f"Transient error fetching {url_path}: HTTP {response.status_code} - {response.text}"
                 )
             else:
                 raise OneDriveClientException(
-                    f"Cannot fetch {url}, response: {response.text}, "
+                    f"Cannot fetch {url_path}, response: {response.text}, "
                     f"status_code: {response.status_code}"
                 )
 
@@ -428,7 +429,7 @@ class OneDriveClient(HttpClient):
             response.raise_for_status()
         except HTTPError as e:
             raise OneDriveClientException(
-                f"Cannot get document libraries for site_url '{site_url}': "
+                f"Cannot get document libraries for site URL '{site_url}': "
                 f"{response.status_code}, {response.text}"
             ) from e
 
@@ -440,6 +441,13 @@ class OneDriveClient(HttpClient):
         folder_path, mask = self._split_path_mask(file_path)
         logging.info(f"Downloading files matching mask {mask} from folder {folder_path}")
         items = self._get_items_based_on_client_type(folder_path, library_name)
+        files = [i for i in items if i.get("file")]
+        folders = [i for i in items if i.get("folder")]
+        unknown = len(items) - len(files) - len(folders)
+        breakdown = f"{len(files)} files, {len(folders)} subfolders"
+        if unknown:
+            breakdown += f", {unknown} unknown"
+        logging.info(f"Found {len(items)} items ({breakdown}) in '{folder_path}'")
         folder_mask = self._create_folder_mask(mask, folder_path)
         self._process_items(items, folder_mask, mask, folder_path, output_dir, last_modified_at, library_name)
 

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -117,9 +117,14 @@ class OneDriveClient(HttpClient):
 
         token = response.json().get("access_token", None)
         if not token:
-            logging.error(response.json())
-            raise OneDriveClientException("Authentication failed, "
-                                          "reauthorize the extractor in extractor configuration.")
+            error_response = response.json()
+            error_code = error_response.get("error", "unknown")
+            error_description = error_response.get("error_description", "No error description provided")
+            logging.error(f"Token refresh failed (HTTP {response.status_code}): {error_code} - {error_description}")
+            raise OneDriveClientException(
+                f"Authentication failed (HTTP {response.status_code}): {error_code} - {error_description}. "
+                f"Reauthorize the extractor in extractor configuration."
+            )
 
         logging.info("New Access token fetched.")
         self.access_token = token
@@ -273,14 +278,16 @@ class OneDriveClient(HttpClient):
         url = f"https://graph.microsoft.com/v1.0/sites/{hostname}:{server_relative_path}"
         headers = {"Authorization": 'Bearer ' + self.access_token}
 
+        logging.info(f"Resolving site URL '{site_url}' via Graph API")
         response = requests.get(url, headers=headers)
 
         if response.status_code == 200:
             site = response.json()
             site_id = site['id']
+            logging.info(f"Resolved site ID: {site_id}")
             return site_id
         else:
-            raise OneDriveClientException(f"Error occurred when fetching site information: "
+            raise OneDriveClientException(f"Error occurred when fetching site information for '{site_url}': "
                                           f"{response.status_code}, {response.text}")
 
     def _get_sharepoint_document_libraries(self):
@@ -400,7 +407,10 @@ class OneDriveClient(HttpClient):
         try:
             response.raise_for_status()
         except HTTPError as e:
-            raise OneDriveClientException(f"Cannot get document libraries for site_url: {site_url}") from e
+            raise OneDriveClientException(
+                f"Cannot get document libraries for site_url '{site_url}': "
+                f"{response.status_code}, {response.text}"
+            ) from e
 
         return response.json()['value']
 

--- a/src/component.py
+++ b/src/component.py
@@ -103,7 +103,7 @@ class Component(ComponentBase):
                 last_error = e
                 logging.warning(f"Refresh token failed: {e}")
         raise UserException(str(last_error)) if last_error else \
-            UserException('Authentication failed, reauthorize the extractor in extractor configuration!')
+            UserException("Authentication failed, reauthorize the extractor in extractor configuration!")
 
     def _get_refresh_tokens(self) -> list[str]:
         state_file = self.get_state_file()

--- a/src/component.py
+++ b/src/component.py
@@ -91,6 +91,7 @@ class Component(ComponentBase):
     def _get_client(self, account_params: Account) -> OneDriveClient:
         tenant_id = account_params.tenant_id
         site_url = account_params.site_url
+        last_error = None
         for refresh_token in self._get_refresh_tokens():
             try:
                 client = OneDriveClient(refresh_token=refresh_token, files_out_folder=self.files_out_path,
@@ -98,10 +99,11 @@ class Component(ComponentBase):
                                         tenant_id=tenant_id, site_url=site_url)
                 self._save_refresh_token_state(client.refresh_token)
                 return client
-            except OneDriveClientException:
-                logging.warning("Refresh token failed, retrying connection with new refresh token.")
-                pass
-        raise UserException('Authentication failed, reauthorize the extractor in extractor configuration!')
+            except OneDriveClientException as e:
+                last_error = e
+                logging.warning(f"Refresh token failed: {e}")
+        raise UserException(str(last_error)) if last_error else \
+            UserException('Authentication failed, reauthorize the extractor in extractor configuration!')
 
     def _get_refresh_tokens(self) -> list[str]:
         state_file = self.get_state_file()


### PR DESCRIPTION
## Summary

Fixes three distinct OAuth/auth bugs in the OneDrive client that surfaced together on a long-running job: the access token expired mid-run, every subsequent request 401'd, and the retry logic broke in three different ways depending on the call site.

### 1. Tenant-specific auth URL for token refresh
Token refresh in `_get_request_tokens()` used the hardcoded `/common` endpoint, which single-tenant Enterprise Apps reject with AADSTS50194. Now uses `self.auth_url`, set per client type:
- Personal OneDrive → `https://login.microsoftonline.com/common`
- OneDrive for Business / SharePoint → `https://login.microsoftonline.com/{tenant_id}`

(`self.authority` → `self.auth_url` rename for consistency with `self.base_url`.)

### 2. Infinite recursion on HTTP 401
When the access token expired mid-run, `get_request()` recursed: 401 → refresh token → retry via recursion → 401 → recurse, until `RecursionError`. The `@backoff` decorator on `_download_file_from_onedrive_url` then retried the whole thing 5 times. Replaced with an iterative 2-attempt loop that refreshes once and surfaces the Microsoft error on the second 401. Added `OneDriveTransientException` so `@backoff` only retries genuine transient errors (429/5xx), not auth failures.

### 3. Bearer header on pre-signed download URLs
`@microsoft.graph.downloadUrl` is a pre-signed URL with its own `tempauth` JWT in the query string — it does not need (and on personal OneDrive's `microsoftpersonalcontent.com` CDN, actively rejects) the Graph API Bearer header. The old code routed downloads through `self.get_request()`, which always attaches the Bearer token. Now uses `self.get_raw(url, is_absolute_path=True, stream=True, ignore_auth=True)` — keeps the HttpClient retry session, drops the Bearer header. Business/SharePoint accounts tolerated the extra header which is why telemetry only showed personal accounts failing.

### Other improvements
- Microsoft error code/description now propagated through exception messages (previously lost; never reached Datadog).
- Token-refresh / per-file / site-resolution logs downgraded from `info` to `debug` to cut noise.
- Per-folder traversal log: `Found N items (X files, Y subfolders[, Z unknown]) in '/path'` — previously zero visibility into traversal scale.
- URLs in error logs sanitized to path-only (`urlparse(url).path`) so `tempauth` JWTs can never leak even if a future caller routes a pre-signed URL through `get_request()`.
- Fixed GitHub Actions workflow triggers, branch resolution, and image-tag step.

## Testing
- Client's stack — initially with tag `1.0.9-fix-tenant-endpoint` for the tenant-URL fix, re-tested successfully with `1777018079-improve-error-logging-26` covering all three fixes.
- Our testing project (personal OneDrive config) — recursion + pre-signed URL fixes verified.

## Review checklist
- [ ] Tenant-specific token refresh works for single-tenant Enterprise Apps
- [ ] Personal OneDrive (`/common` endpoint) still works
- [ ] Long runs that cross the access-token expiry no longer recurse / no longer 401 on downloads
- [ ] Log output at `info` level is readable: client init, folder scan, item counts, download mask

Link to Devin session: https://app.devin.ai/sessions/8b70f85ef2e0408c96eb91f970f5e217
Requested by: @yustme
